### PR TITLE
Fix description matcher usage

### DIFF
--- a/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
@@ -119,7 +119,7 @@ public class Allure2ExportFormatter implements ExportFormatter {
         final Matcher descriptionMatcher = Pattern.compile("allure\\.description:(?<description>.*)")
                 .matcher(activityTitle);
         if (descriptionMatcher.matches()) {
-            context.getResult().setDescription(nameMatcher.group("description"));
+            context.getResult().setDescription(descriptionMatcher.group("description"));
             return;
         }
         final Matcher labelMatcher = Pattern.compile("allure\\.label\\.(?<name>.*?):(?<value>.*)")


### PR DESCRIPTION
xcresults util throws exception when using `allure.description` feature https://github.com/eroshenkoam/xcresults/pull/30

<details>
  <pre>java.lang.IllegalStateException: No match found
	at java.util.regex.Matcher.getMatchedGroupIndex(Matcher.java:1314)
	at java.util.regex.Matcher.group(Matcher.java:572)
	at io.eroshenkoam.xcresults.export.Allure2ExportFormatter.parseStep(Allure2ExportFormatter.java:122)
	at io.eroshenkoam.xcresults.export.Allure2ExportFormatter.parseStep(Allure2ExportFormatter.java:186)
	at io.eroshenkoam.xcresults.export.Allure2ExportFormatter.parseStep(Allure2ExportFormatter.java:186)
	at io.eroshenkoam.xcresults.export.Allure2ExportFormatter.format(Allure2ExportFormatter.java:73)
	at io.eroshenkoam.xcresults.export.ExportCommand.exportTestSummary(ExportCommand.java:169)
	at io.eroshenkoam.xcresults.export.ExportCommand.lambda$runUnsafe$2(ExportCommand.java:132)
	at java.util.HashMap.forEach(HashMap.java:1289)
	at io.eroshenkoam.xcresults.export.ExportCommand.runUnsafe(ExportCommand.java:131)
	at io.eroshenkoam.xcresults.export.ExportCommand.run(ExportCommand.java:86)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2141)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at io.eroshenkoam.xcresults.XCResults.main(XCResults.java:13)
 </pre>
</details>

**Steps to reproduce:**
1. Log activity with format `allure.description:string`
2. Run tests, generate test_result
3. Run `xcresults export <test_result> <output_path>`