### PR TITLE
Handling case when there are no tests in testable summary

### DIFF
--- a/src/main/java/io/eroshenkoam/xcresults/export/ExportCommand.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/ExportCommand.java
@@ -117,10 +117,14 @@ public class ExportCommand implements Runnable {
             for (JsonNode summary : testRef.get(SUMMARIES).get(VALUES)) {
                 for (JsonNode testableSummary : summary.get(TESTABLE_SUMMARIES).get(VALUES)) {
                     final ExportMeta testMeta = getTestMeta(meta, testableSummary);
-                    for (JsonNode test : testableSummary.get(TESTS).get(VALUES)) {
-                        getTestSummaries(test).forEach(testSummary -> {
-                            testSummaries.put(testSummary, testMeta);
-                        });
+                    if (testableSummary.has(TESTS) && testableSummary.get(TESTS).has(VALUES)) {
+                        for (JsonNode test : testableSummary.get(TESTS).get(VALUES)) {
+                            getTestSummaries(test).forEach(testSummary -> {
+                                testSummaries.put(testSummary, testMeta);
+                            });
+                        }
+                    } else {
+                        System.out.printf("No tests found for '%s'%n", testableSummary.get("name").get(VALUE));
                     }
                 }
             }


### PR DESCRIPTION
When running the command, we would get an error:
```java
java.lang.NullPointerException
	at io.eroshenkoam.xcresults.export.ExportCommand.lambda$runUnsafe$1(ExportCommand.java:120)
	at java.base/java.util.HashMap.forEach(HashMap.java:1339)
	at io.eroshenkoam.xcresults.export.ExportCommand.runUnsafe(ExportCommand.java:115)
	at io.eroshenkoam.xcresults.export.ExportCommand.run(ExportCommand.java:86)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1769)
	at picocli.CommandLine.access$900(CommandLine.java:145)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2141)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2108)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:1975)
	at picocli.CommandLine.execute(CommandLine.java:1904)
	at io.eroshenkoam.xcresults.XCResults.main(XCResults.java:13)
```

After debugging it turned out that there was an empty **XCTestCase** without tests in the application target, so the export failed.
Added a check for the presence of tests, if they are not, then display a message about it in the log.

Perhaps this partially closes the issue #33 