### PR TITLE
Test duration fix

### DIFF
--- a/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
@@ -102,6 +102,7 @@ public class Allure2ExportFormatter implements ExportFormatter {
                 result.setStop(result.getStart() + durationToMillis);
             }
             if (result.getSteps().size() > 0) {
+                result.setStart(result.getSteps().get(0).getStart());
                 result.setStop(result.getSteps().get(result.getSteps().size() - 1).getStop());
             }
         }


### PR DESCRIPTION
If we take the test duration from test steps we should not only take stop time from the last step but also start time from the first test.
Otherwise start time from meta is not consistent with stop time from the last step and we get incorrect durations in allure report
![Screenshot 2022-11-25 at 12 37 55](https://user-images.githubusercontent.com/892176/203954321-ebb26e69-8cd5-4853-8c21-ae7f55ae8152.png)
