### PR TITLE
Add expected failure status

### DIFF
--- a/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/Allure2ExportFormatter.java
@@ -281,6 +281,7 @@ public class Allure2ExportFormatter implements ExportFormatter {
 
         switch (status) {
             case "Success":
+            case "Expected Failure":
                 return Status.PASSED;
             case "Failure":
                 return Status.FAILED;


### PR DESCRIPTION
If you use XCTExpectFailure in your tests, test status in xcresult file is 'Expected Failure' instead of 'Success'. This results in null status in allure report, although test was successful.
```
func test() {
  XCTExpectFailure()
  XCTFail()
}
```
<img width="310" alt="image" src="https://github.com/eroshenkoam/xcresults/assets/8699724/7850b39c-58a5-4820-a181-6569a34c89df">

Here test report with such test
[Test-testLocation-2023.08.24_18-01-44-+0300.xcresult.zip](https://github.com/eroshenkoam/xcresults/files/12430769/Test-testLocation-2023.08.24_18-01-44-%2B0300.xcresult.zip)
