### PR TITLE
Fix xcresults export for Xcode 16

### DIFF
--- a/src/main/java/io/eroshenkoam/xcresults/export/ExportProcessor.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/ExportProcessor.java
@@ -230,6 +230,7 @@ public class ExportProcessor {
                 "xcrun",
                 "xcresulttool",
                 "get",
+                "--legacy",
                 "--format", "json",
                 "--path", inputPath.toAbsolutePath().toString()
         );
@@ -242,6 +243,7 @@ public class ExportProcessor {
                 "xcrun",
                 "xcresulttool",
                 "get",
+                "--legacy",
                 "--format", "json",
                 "--path", inputPath.toAbsolutePath().toString(),
                 "--id", id

--- a/src/main/java/io/eroshenkoam/xcresults/export/ExportProcessor.java
+++ b/src/main/java/io/eroshenkoam/xcresults/export/ExportProcessor.java
@@ -257,14 +257,17 @@ public class ExportProcessor {
                 "xcrun",
                 "xcresulttool",
                 "export",
-                "--type", "file",
                 "--path", inputPath.toAbsolutePath().toString(),
+                "--type", "file",
+                "--output-path", output.toAbsolutePath().toString(),
                 "--id", id,
-                "--output-path", output.toAbsolutePath().toString()
+                "--legacy"
         );
-        readProcessOutput(exportBuilder);
-        if (FILE_EXTENSION_HEIC.equals(FilenameUtils.getExtension(output.toString()))) {
-            convertHeicToJpeg(output);
+
+        try {
+            exportBuilder.start();
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
```
xcrun xcresulttool get --format json --path ***.xcresult

Error: This command is deprecated and will be removed in a future release, --legacy flag is required to use it.
Usage: xcresulttool get object [--legacy] --path <path> [--id <id>] [--version <version>] [--format <format>]
  See 'xcresulttool get object --help' for more information.
```

This seems to be the issue. As a quick hack I added the legacy option, but it might break Xcode 15 build. My solution is to rebuild the binary for Xcode 16 specifically 

[xcresults.zip](https://github.com/user-attachments/files/17101121/xcresults.zip)

Extract to Desktop, then

```
sudo cp ~/Desktop/xcresults /usr/local/bin/xcresults
sudo chmod +x /usr/local/bin/xcresults
```

> Note!
> 
> This binary won't fix the attachment issue, but it will avoid the error on export and send results to allure.

https://github.com/eroshenkoam/xcresults/issues/73
https://github.com/eroshenkoam/xcresults/issues/72